### PR TITLE
add `/redirect/paseto` to golang implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -6,6 +6,5 @@ FROM golang:1.17-buster
   ENV CLIENT_SECRET=
   ENV REDIRECT_URL=
   
+  EXPOSE 3000
   CMD go run main.go
-
-  EXPOSE 3000:3000


### PR DESCRIPTION
provides a way of entering Connect Flow using a PASETO `customer_token`